### PR TITLE
feat: add purchase and consignment list/get operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for the list and get purchase operations in `PurchaseAPI`
+* Support for the list and get consignment operations in `ConsignmentAPI`
 
 ### Changed
 

--- a/src/omni/__init__.py
+++ b/src/omni/__init__.py
@@ -27,6 +27,7 @@ __license__ = "Apache License, Version 2.0"
 
 from . import models
 from . import base
+from . import consignment
 from . import consignment_out
 from . import consignment_slip
 from . import contactable
@@ -46,6 +47,7 @@ from . import merchandise
 from . import money_sale_slip
 from . import named
 from . import product
+from . import purchase
 from . import receipt
 from . import return_
 from . import saft_pt
@@ -66,6 +68,7 @@ from . import web
 
 from .models import *
 from .base import BASE_URL, API, Base, BaseDelta
+from .consignment import ConsignmentAPI
 from .consignment_out import ConsignmentOutAPI
 from .consignment_slip import ConsignmentSlipAPI
 from .contactable import Contactable
@@ -85,6 +88,7 @@ from .merchandise import MerchandiseAPI
 from .money_sale_slip import MoneySaleSlipAPI
 from .named import Named
 from .product import ProductAPI
+from .purchase import PurchaseAPI
 from .receipt import ReceiptAPI
 from .return_ import ReturnAPI
 from .saft_pt import SaftPtAPI, SaftPtReport, SaftPtReportDelta, SaftPtReportPayload

--- a/src/omni/base.py
+++ b/src/omni/base.py
@@ -43,6 +43,7 @@ from . import saft_pt
 from . import invoice
 from . import product
 from . import receipt
+from . import purchase
 from . import customer
 from . import supplier
 from . import transfer
@@ -52,6 +53,7 @@ from . import sale_order
 from . import credit_note
 from . import sub_product
 from . import merchandise
+from . import consignment
 from . import identifiable
 from . import sale_snapshot
 from . import inventory_line
@@ -104,6 +106,7 @@ class API(
     invoice.InvoiceAPI,
     product.ProductAPI,
     receipt.ReceiptAPI,
+    purchase.PurchaseAPI,
     customer.CustomerAPI,
     supplier.SupplierAPI,
     transfer.TransferAPI,
@@ -113,6 +116,7 @@ class API(
     credit_note.CreditNoteAPI,
     sub_product.SubProductAPI,
     merchandise.MerchandiseAPI,
+    consignment.ConsignmentAPI,
     identifiable.IdentifiableAPI,
     sale_snapshot.SaleSnapshotAPI,
     inventory_line.InventoryLineAPI,

--- a/src/omni/base.pyi
+++ b/src/omni/base.pyi
@@ -2,11 +2,13 @@ from typing import Any, Mapping, NotRequired, Sequence, TypedDict
 
 from appier import OAuth2API
 
+from .consignment import ConsignmentAPI
 from .customer import CustomerAPI
 from .employee import EmployeeAPI
 from .identifiable import IdentifiableAPI
 from .inventory_check import InventoryCheckAPI
 from .merchandise import MerchandiseAPI
+from .purchase import PurchaseAPI
 from .saft_pt import SaftPtAPI
 from .sale import SaleAPI
 from .store import StoreAPI
@@ -40,9 +42,11 @@ class API(
     UserAPI,
     StoreAPI,
     SaftPtAPI,
+    PurchaseAPI,
     CustomerAPI,
     EmployeeAPI,
     MerchandiseAPI,
+    ConsignmentAPI,
     IdentifiableAPI,
     InventoryCheckAPI,
 ):

--- a/src/omni/consignment.py
+++ b/src/omni/consignment.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Omni ERP
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Omni ERP.
+#
+# Hive Omni ERP is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Omni ERP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Omni ERP. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+from . import util
+
+
+class ConsignmentAPI(object):
+
+    def list_consignments(self, *args, **kwargs):
+        util.filter_args(kwargs)
+        url = self.base_url + "omni/consignments.json"
+        contents = self.get(url, **kwargs)
+        return contents
+
+    def create_consignment(self, payload):
+        url = self.base_url + "omni/consignments.json"
+        contents = self.post(url, data_j=payload)
+        return contents
+
+    def get_consignment(self, object_id):
+        url = self.base_url + "omni/consignments/%d.json" % object_id
+        contents = self.get(url)
+        return contents

--- a/src/omni/consignment.pyi
+++ b/src/omni/consignment.pyi
@@ -1,9 +1,19 @@
 from typing import Sequence
 
+from .price import Price
+from .employee import Employee
 from .operation import Operation
 
 class Consignment(Operation):
-    pass
+    workflow_state: int
+    start_date: float
+    end_date: float | None
+    vat: float
+    discount: float
+    discount_vat: float
+    communication_frequency: float | None
+    price: Price
+    primary_buyer: Employee
 
 class ConsignmentAPI(object):
     def list_consignments(self, *args, **kwargs) -> Sequence[Consignment]: ...

--- a/src/omni/consignment.pyi
+++ b/src/omni/consignment.pyi
@@ -1,0 +1,11 @@
+from typing import Sequence
+
+from .operation import Operation
+
+class Consignment(Operation):
+    pass
+
+class ConsignmentAPI(object):
+    def list_consignments(self, *args, **kwargs) -> Sequence[Consignment]: ...
+    def create_consignment(self, payload: Consignment) -> Consignment: ...
+    def get_consignment(self, object_id: int) -> Consignment: ...

--- a/src/omni/consignment.pyi
+++ b/src/omni/consignment.pyi
@@ -2,15 +2,14 @@ from typing import Sequence
 
 from .price import Price
 from .employee import Employee
-from .operation import Operation
+from .workflow_operation import WorkflowOperation
 
-class Consignment(Operation):
-    workflow_state: int
+class Consignment(WorkflowOperation):
     start_date: float
     end_date: float | None
     vat: float
     discount: float
-    discount_vat: float
+    discount_vat: float | None
     communication_frequency: float | None
     price: Price
     primary_buyer: Employee

--- a/src/omni/purchase.py
+++ b/src/omni/purchase.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Omni ERP
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Omni ERP.
+#
+# Hive Omni ERP is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Omni ERP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Omni ERP. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+from . import util
+
+
+class PurchaseAPI(object):
+
+    def list_purchases(self, *args, **kwargs):
+        util.filter_args(kwargs)
+        url = self.base_url + "omni/purchases.json"
+        contents = self.get(url, **kwargs)
+        return contents
+
+    def create_purchase(self, payload):
+        url = self.base_url + "omni/purchases.json"
+        contents = self.post(url, data_j=payload)
+        return contents
+
+    def get_purchase(self, object_id):
+        url = self.base_url + "omni/purchases/%d.json" % object_id
+        contents = self.get(url)
+        return contents

--- a/src/omni/purchase.pyi
+++ b/src/omni/purchase.pyi
@@ -5,11 +5,11 @@ from .employee import Employee
 from .operation import Operation
 
 class Purchase(Operation):
-    financial_discount: float
-    financial_discount_vat: float
+    financial_discount: float | None
+    financial_discount_vat: float | None
     vat: float
     discount: float
-    discount_vat: float
+    discount_vat: float | None
     price: Price
     primary_buyer: Employee
 

--- a/src/omni/purchase.pyi
+++ b/src/omni/purchase.pyi
@@ -1,9 +1,17 @@
 from typing import Sequence
 
+from .price import Price
+from .employee import Employee
 from .operation import Operation
 
 class Purchase(Operation):
-    pass
+    financial_discount: float
+    financial_discount_vat: float
+    vat: float
+    discount: float
+    discount_vat: float
+    price: Price
+    primary_buyer: Employee
 
 class PurchaseAPI(object):
     def list_purchases(self, *args, **kwargs) -> Sequence[Purchase]: ...

--- a/src/omni/purchase.pyi
+++ b/src/omni/purchase.pyi
@@ -1,0 +1,11 @@
+from typing import Sequence
+
+from .operation import Operation
+
+class Purchase(Operation):
+    pass
+
+class PurchaseAPI(object):
+    def list_purchases(self, *args, **kwargs) -> Sequence[Purchase]: ...
+    def create_purchase(self, payload: Purchase) -> Purchase: ...
+    def get_purchase(self, object_id: int) -> Purchase: ...

--- a/src/omni/workflow_operation.pyi
+++ b/src/omni/workflow_operation.pyi
@@ -1,4 +1,5 @@
 from .operation import Operation
 
 class WorkflowOperation(Operation):
-    workflow_state: int
+    workflow_state: int | None
+

--- a/src/omni/workflow_operation.pyi
+++ b/src/omni/workflow_operation.pyi
@@ -1,0 +1,4 @@
+from .operation import Operation
+
+class WorkflowOperation(Operation):
+    workflow_state: int

--- a/src/omni/workflow_operation.pyi
+++ b/src/omni/workflow_operation.pyi
@@ -2,4 +2,3 @@ from .operation import Operation
 
 class WorkflowOperation(Operation):
     workflow_state: int | None
-


### PR DESCRIPTION
## Summary

Adds upstream client support for the Omni ERP purchases module, mirroring the existing read/write API mixins (e.g. `TransferAPI`).

- `PurchaseAPI` — `list_purchases`, `create_purchase`, `get_purchase` (`omni/purchases.json`)
- `ConsignmentAPI` — `list_consignments`, `create_consignment`, `get_consignment` (`omni/consignments.json`)
- Both classes registered in the composed `API` and re-exported from `omni`.

## Testing

- `python setup.py test`
- `black .`